### PR TITLE
Move auth.yaml to secret, some misc changes (listed in the description)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "0.7"
 description: Deploys the Flowmill agent in Kubernetes as a DaemonSet
 name: flowmill-k8s
-version: 0.1.0
+version: 0.1.1
 icon: https://www.flowmill.com/apple-touch-icon-152x152.png

--- a/README.md
+++ b/README.md
@@ -1,12 +1,33 @@
-## Deploying:
 
-* Download your auth.yaml file from the UI; drop it in the config/ subdirectory
-* Optional: update config/config.yaml with your Kubernetes cluster name
+# Prerequisites
+
+Flowmill will provide (via the config tab on your UI) an auth.yaml file for you. You can deploy this to your cluster manually and update the `flowmill.authYamlExistingSecret` value to that secret name, or simply paste the contents of this file into the `Values.yaml`.
+
+* Download your auth.yaml and paste into Values.yaml or deploy manually.
+* Optionally name your cluster in `.flowmill.clusterName`.
 * Install kernel headers on all nodes in your cluster:
   * sudo apt-get install --yes linux-headers-$(uname -r)  # For Debian, Ubuntu
   * sudo yum install -y kernel-devel-$(uname -r)  # For RHEL, CentOS, Amazon Linux
-* helm install ./ --name flowmill-k8s --namespace flowmill
 
-## Upgrading:
+## Deploying
 
-* helm upgrade flowmill-k8s ./
+Manually, using Helm:
+```helm install ./ --name flowmill-k8s --namespace flowmill```
+
+Using [Ship](https://github.com/replicatedhq/ship):
+```
+brew tap replicatedhq/ship
+brew install ship
+ship init github.com/Flowmill/flowmill-k8s
+```
+
+## Upgrading
+
+Manually, using Helm:
+```helm upgrade flowmill-k8s ./```
+
+Using Ship:
+```
+ship watch && ship udpate```
+```
+

--- a/config/README.md
+++ b/config/README.md
@@ -1,5 +1,0 @@
-## Client (agent) config and auth files
-
-Flowmill will provide (via the config tab on your UI) an auth.yaml file for you to place in this directory.
-
-You may want to update the config.yaml with your k8s cluster name.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,0 @@
-# Please modify the label as you like.
-labels:
-  environment: my-kubernetes-cluster

--- a/templates/agent-daemonset.yaml
+++ b/templates/agent-daemonset.yaml
@@ -1,4 +1,3 @@
----
 # Flowmill agent daemonset: deploys the flowmill agent to each node
 # in the cluster.  The agent needs to be able to compile and install
 # eBPF programs in the node's kernel, so needs to run as root and
@@ -38,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           # TODO: liveness probe
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.agent.resources | indent 12 }}
           securityContext:
             privileged: true
           volumeMounts:
@@ -50,6 +49,9 @@ spec:
             readOnly: true
           - mountPath: /etc/flowmill
             name: {{ include "flowmill-agent-k8s.fullname" . }}-config
+          - mountPath: /etc/flowmill/auth.yaml
+            name: flowmill-k8s-auth-config
+            subPath: auth.yaml
           # FIXME: define & mount config
       hostNetwork: true
       hostPID: true
@@ -57,6 +59,13 @@ spec:
       - name: {{ include "flowmill-agent-k8s.fullname" . }}-config
         configMap:
           name: {{ include "flowmill-k8s.fullname" . }}-config
+      - name: flowmill-k8s-auth-config
+        secret:
+{{- if not .Values.flowmill.authYamlExistingSecret }}
+          secretName: {{ template "flowmill-k8s.fullname" . }}-auth
+{{- else }}
+          secretName: {{ .Values.flowmill.authYamlExistingSecret }}
+{{- end }}
       - name: usr-src
         hostPath:
           path: /usr/src

--- a/templates/authsecret.yaml
+++ b/templates/authsecret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.flowmill.authYamlExistingSecret }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "flowmill-k8s.fullname" . }}-auth
+  labels:
+    app: "{{ template "flowmill-k8s.fullname" . }}"
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: Opaque
+stringData:
+{{ toYaml .Values.flowmill.authYaml | indent 4 }}
+
+{{- end }}

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.create -}}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/clusterrolebinding.yaml
+++ b/templates/clusterrolebinding.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.create -}}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,4 +1,3 @@
----
 # This configmap includes auth.yaml (which is used for both the agent and the k8s-relay
 # containers) and config.yaml (currently only used by the agent).
 apiVersion: v1
@@ -7,4 +6,7 @@ metadata:
   name: {{ include "flowmill-k8s.fullname" . }}-config
   namespace: {{ .Release.Namespace | quote }}
 data:
-  {{- (.Files.Glob "config/*.yaml").AsConfig | nindent 2 }}
+  config.yaml: |
+    labels:
+      environment: {{ .Values.flowmill.clusterName }}
+

--- a/templates/k8s-collector-deployment.yaml
+++ b/templates/k8s-collector-deployment.yaml
@@ -1,4 +1,3 @@
----
 # The Flowmill k8s collector consists of two services:
 # 1) k8s-watcher: talks to the Kubernetes API server to determine the current state of
 #    the cluster; sets up watches to be notified of subsequent changes to pods, services
@@ -36,7 +35,8 @@ spec:
       - image: 966881513036.dkr.ecr.us-east-1.amazonaws.com/flowmill/flowmill-k8s-watcher:latest
         imagePullPolicy: Always
         name: flowmill-k8s-watcher
-        resources: {}
+        resources:
+{{ toYaml .Values.collector.resources | indent 12 }}
       # k8s-relay, which is a service that the k8s collector talks to.
       # Currently not configurable, has to be reachable on localhost:8172, so must
       # share a pod with the k8s collector above.  Talks in turn to flowmill-server
@@ -48,10 +48,20 @@ spec:
         volumeMounts:
         - mountPath: /etc/flowmill
           name: flowmill-k8s-relay-config
+        - mountPath: /etc/flowmill/auth.yaml
+          name: flowmill-k8s-auth-config
+          subPath: auth.yaml
       volumes:
       - name: flowmill-k8s-relay-config
         configMap:
           name: {{ include "flowmill-k8s.fullname" . }}-config
+      - name: flowmill-k8s-auth-config
+        secret:
+{{- if not .Values.flowmill.authYamlExistingSecret }}
+          secretName: {{ template "flowmill-k8s.fullname" . }}-auth
+{{- else }}
+          secretName: {{ .Values.flowmill.authYamlExistingSecret }}
+{{- end }}
       securityContext: {}
       {{- if .Values.rbac.create }}
       serviceAccount: {{ include "flowmill-k8s-collector.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,6 @@
 # Default values for flowmill-agent-k8s.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
----
 image:
   repository: 966881513036.dkr.ecr.us-east-1.amazonaws.com/flowmill/flowmill-agent
   tag: latest
@@ -25,6 +24,27 @@ tolerations:
   effect: "NoExecute"
 - operator: "Exists"
   effect: "NoSchedule"
+
+flowmill:
+  clusterName: my-kubernetes-cluster
+
+  # Set this to the name of an existing secret if this is already deployed
+  # authYamlExistingSecret:
+
+  authYaml:
+    dst: MISSING
+    port: MISSING
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      ....
+      -----END PRIVATE KEY-----
+    crt: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    auth: MISSING
+    apikey: MISSING
+    tenant: MISSING
 
 affinity: {}
 


### PR DESCRIPTION
A few suggested changes:

1. Moved the auth.yaml to a secret, so that it can be deployed in production with as a [SealedSecret](https://github.com/bitnami-labs/sealed-secrets). This just helps anyone who's using gitops or checking the YAML into a repo.
2. Added the resources template to template in from values to the daemonset and deployment, if present.
3. Optionally, allowed for an existing secret name to be used, so that existing processes can deploy that secret. This is opt-in, by setting the value in the helm Values.yaml.
4. Bumped the version of the Chart to support this.
5. Removed some `---` from the Values.yaml (and a few other files) to be consistent with other Helm charts in the stable repo.
6. Updated the README with instructions on deploying the secret (auth.yaml) or how to put it into the Values.yaml. 
7. Added guidance on using [Ship](https://github.com/replicatedhq/ship) to operationalize the Helm chart and keep it updated easier.

